### PR TITLE
Fix for Windows mouse movement coordinate rounding (issue #28)

### DIFF
--- a/src/mouse.c
+++ b/src/mouse.c
@@ -31,10 +31,10 @@ void moveMouse(MMPoint point)
 	             0, 0, 0, 0, point.x, point.y);
 	XFlush(display);
 #elif defined(IS_WINDOWS)
-	point.x *= 0xFFFF / GetSystemMetrics(SM_CXSCREEN);
-	point.y *= 0xFFFF / GetSystemMetrics(SM_CYSCREEN);
+  int x = point.x * 0xFFFF / GetSystemMetrics(SM_CXSCREEN);
+  int y = point.y * 0xFFFF / GetSystemMetrics(SM_CYSCREEN);
 	mouse_event(MOUSEEVENTF_ABSOLUTE | MOUSEEVENTF_MOVE,
-	            (DWORD)point.x, (DWORD)point.y, 0, 0);
+	            (DWORD)x, (DWORD)y, 0, 0);
 #endif
 }
 


### PR DESCRIPTION
Fix for Windows mouse movement coordinate rounding described in https://github.com/msanders/autopy/issues/28
