### PR TITLE
Fix Windows multiple display size (Issue #36)

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -21,8 +21,13 @@ MMSize getMainDisplaySize(void)
 	return MMSizeMake((size_t)DisplayWidth(display, screen),
 	                  (size_t)DisplayHeight(display, screen));
 #elif defined(IS_WINDOWS)
-	return MMSizeMake((size_t)GetSystemMetrics(SM_CXSCREEN),
-	                  (size_t)GetSystemMetrics(SM_CYSCREEN));
+	if (GetSystemMetrics(SM_CMONITORS) == 1) {
+ 		return MMSizeMake((size_t)GetSystemMetrics(SM_CXSCREEN),
+ 		                  (size_t)GetSystemMetrics(SM_CYSCREEN));
+ 	} else 	{
+ 		return MMSizeMake((size_t)GetSystemMetrics(SM_CXVIRTUALSCREEN),
+ 		                  (size_t)GetSystemMetrics(SM_CYVIRTUALSCREEN));
+ 	}
 #endif
 }
 


### PR DESCRIPTION
Fixed getMainDisplaySize to look at SM_CXVIRTUALSCREEN and SM_CYVIRTUALSCREEN instead of SM_CXSCREEN and SM_CYSCREEN if Windows says more than one monitor is attached.
